### PR TITLE
Add disposer API

### DIFF
--- a/src/confirmer.js
+++ b/src/confirmer.js
@@ -4,14 +4,19 @@ export const CANCELLED = 'cancelled';
 
 export default class Confirmer {
   constructor(initFn) {
+    let disposer = () => {};
     this._promise = new Promise((resolve, reject) => {
       initFn({
         error: reject,
         reject: value => resolve({reason: REJECTED, value}),
         confirm: value => resolve({reason: CONFIRMED, value}),
-        cancel: value => resolve({reason: CANCELLED, value})
+        cancel: value => resolve({reason: CANCELLED, value}),
+        dispose: fn => disposer = fn
       });
-    });
+    }).then(
+      result => Promise.resolve(disposer()).then(() => result),
+      error => Promise.resolve(disposer()).then(() => { throw error; })
+    );
   }
 
   onConfirmed(fn) {


### PR DESCRIPTION
I thought that keeping all the setup event handling and removing in one place would allow simple use of the resolver object and prevent having to expose functions to the outer scope.

The normal way to handle this would look like:

```js
let outerResolver;
new Confirmer(resolver => {
  domNode1.addEventListener('click', resolver.confirm);
  domNode2.addEventListener('click', resolver.cancel);
  outerResolver = resolver;
})
.onDone(() => {
  domNode1.removeEventListener('click', outerResolver.confirm);
  domNode2.removeEventListener('click', outerResolver.cancel);
});
```

Which never felt right. Now I propose one can accomplish this with:

```js
new Confirmer(resolver => {
  domNode1.addEventListener('click', resolver.confirm);
  domNode2.addEventListener('click', resolver.cancel);
  resolver.dispose(() => {
    domNode1.removeEventListener('click', resolver.confirm);
    domNode2.removeEventListener('click', resolver.cancel);
  });
});
```

Which I think looks nicer.