### PR TITLE
Mutatable Chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,31 +82,221 @@ new Confirmer(function (resolver) { … })
 The `reason` being one of `rejected`, `confirmed`, or `cancelled`. And the
 `value` is the value passed to one of the resolver functions.
 
-The following methods are chainable:
+## API
 
-#### `onCanceled`
+<a name="Confirmer"></a>
 
-Is called when `resolver.cancel()` is triggered. Used to denote that the
-confirmation was cancelled and perhaps should do nothing.
+### Confirmer
+The main class is referred to as `Confirmer` though the packaging is called
+`confirmed` This is simply to prevent an NPM name collision but the proper
+term for this utility is `Confirmer` and is referenced as such in this
+documentation.
 
-#### `onConfirmed`
+**Kind**: global class  
 
-Is called when `resolver.confirm()` is triggered. Used to denote that the user
-has confirmed in some way. ("OK" button, correct login credentials, etc.)
+* [Confirmer](#Confirmer)
+    * [new Confirmer(initFn)](#new_Confirmer_new)
+    * _instance_
+        * [.onConfirmed(fn)](#Confirmer+onConfirmed) ⇒ [<code>Confirmer</code>](#Confirmer)
+        * [.onRejected(fn)](#Confirmer+onRejected) ⇒ [<code>Confirmer</code>](#Confirmer)
+        * [.onCancelled(fn)](#Confirmer+onCancelled) ⇒ [<code>Confirmer</code>](#Confirmer)
+        * ~~[.onCanceled()](#Confirmer+onCanceled)~~
+        * [.onDone(fn)](#Confirmer+onDone) ⇒ [<code>Confirmer</code>](#Confirmer)
+        * [.then(onFulfilled, onRejected)](#Confirmer+then) ⇒ <code>Promise</code>
+        * [.catch(onRejected)](#Confirmer+catch) ⇒ <code>Promise</code>
+    * _static_
+        * [.resolve(result)](#Confirmer.resolve) ⇒ [<code>Confirmer</code>](#Confirmer)
 
-#### `onRejected`
 
-Is called when `resolver.rejected()` is triggered. Used to denote that the user
-has performed an action that denied the confirmation. ("No" button, bad
-password, etc.)
+* * *
 
-#### `onDone`
+<a name="new_Confirmer_new"></a>
 
-Is called when **any** of the resolver functions are triggered. This is used for
-clean up like closing the dialog and removing stale event handlers. This is also
-called if the `resolver.error` is triggered or something throws an exception in
-the initialization function (which can be captued by the `catch()` function just
-like a promise).
+#### new Confirmer(initFn)
+Much like the `Promise` API the constructor for the `Confirmer` takes a
+function. That function is passed a resolver object which has three
+functions on it that you can use to *fulfill* the `Confirmer`, one
+function to register an error, and a disposer function to clean up
+resources is needed. Each fulfillment function can take an optional value.
+
+#### Example
+```js
+new Confirmer(function (resolver) {
+  // Affirm confirmation
+  resolver.confirm();
+  // Reject confirmation
+  resolver.reject();
+  // Cancel confirmation
+  resolver.cancel();
+  // Reject with an Error
+  resolver.error(new Error());
+  // Register a disposer function to clean up resources
+  // Same as onDone but in the initializer function closure
+  resolver.dispose(function () { … });
+});
+```
+
+**Params**
+
+- initFn <code>function</code> - The initializer function
+
+
+* * *
+
+<a name="Confirmer+onConfirmed"></a>
+
+#### confirmer.onConfirmed(fn) ⇒ [<code>Confirmer</code>](#Confirmer)
+Register callback that is called when `resolver.confirm()` is triggered.
+Used to denote that the user has confirmed in some way. ("OK" button,
+correct login credentials, etc.)
+
+If the callback returns a new Confirmer the result will be that new
+Confirmer allowing the callback to change the fulfillment reason as part
+of the chaining. If it is simply a scalar value the fulfillment reason
+with remain the same but the value will change.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Returns**: [<code>Confirmer</code>](#Confirmer) - A new Confirmer instance for chaining  
+**Params**
+
+- fn <code>function</code> - callback function called when Confirmer is confirmed
+
+
+* * *
+
+<a name="Confirmer+onRejected"></a>
+
+#### confirmer.onRejected(fn) ⇒ [<code>Confirmer</code>](#Confirmer)
+Register callback that is called when `resolver.rejected()` is triggered.
+Used to denote that the user has performed an action that denied the
+confirmation. ("No" button, bad password, etc.)
+
+If the callback returns a new Confirmer the result will be that new
+Confirmer allowing the callback to change the fulfillment reason as part
+of the chaining. If it is simply a scalar value the fulfillment reason
+with remain the same but the value will change.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Returns**: [<code>Confirmer</code>](#Confirmer) - A new Confirmer instance for chaining  
+**Params**
+
+- fn <code>function</code> - callback function called when Confirmer is rejected
+
+
+* * *
+
+<a name="Confirmer+onCancelled"></a>
+
+#### confirmer.onCancelled(fn) ⇒ [<code>Confirmer</code>](#Confirmer)
+Register callback that is called when `resolver.cancel()` is triggered.
+Used to denote that the confirmation was cancelled and perhaps should do
+nothing.
+
+If the callback returns a new Confirmer the result will be that new
+Confirmer allowing the callback to change the fulfillment reason as part
+of the chaining. If it is simply a scalar value the fulfillment reason
+with remain the same but the value will change.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Returns**: [<code>Confirmer</code>](#Confirmer) - A new Confirmer instance for chaining  
+**Params**
+
+- fn <code>function</code> - callback function called when Confirmer is cancelled
+
+
+* * *
+
+<a name="Confirmer+onCanceled"></a>
+
+#### ~~confirmer.onCanceled()~~
+***Deprecated***
+
+Spelling error; use `onCancelled`.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+
+* * *
+
+<a name="Confirmer+onDone"></a>
+
+#### confirmer.onDone(fn) ⇒ [<code>Confirmer</code>](#Confirmer)
+Register a callback that is called when any of the resolver functions are
+triggered. This is used for clean up like closing the dialog and removing
+stale event handlers. This is also called if the `resolver.error()` is
+triggered or something throws an exception in the initialization function
+(which can be captured by the `catch()` function just like a promise).
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Returns**: [<code>Confirmer</code>](#Confirmer) - A new Confirmer instance for chaining  
+**Params**
+
+- fn <code>function</code> - callback function called when Confirmer is resolved/errored
+
+
+* * *
+
+<a name="Confirmer+then"></a>
+
+#### confirmer.then(onFulfilled, onRejected) ⇒ <code>Promise</code>
+Cast to a `Promise`. Will proxy to the internal promise `then()` method.
+Since the result is a Promise it will not chain as Confirmer after this.
+
+The result of a fulfilled promise is an Object with `reason` and `value`
+properties. See [resolve](#Confirmer.resolve) for more details of this
+internal object.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Params**
+
+- onFulfilled <code>function</code> - callback when internal promise is fulfilled
+- onRejected <code>function</code> - callback when internal promise is rejected
+
+
+* * *
+
+<a name="Confirmer+catch"></a>
+
+#### confirmer.catch(onRejected) ⇒ <code>Promise</code>
+Cast to a `Promise`. Will proxy to the internal promise `catch()` method.
+Since the result is a Promise it will not chain as Confirmer after this.
+
+**Kind**: instance method of [<code>Confirmer</code>](#Confirmer)  
+**Params**
+
+- onRejected <code>function</code> - callback when internal promise is rejected
+
+
+* * *
+
+<a name="Confirmer.resolve"></a>
+
+#### Confirmer.resolve(result) ⇒ [<code>Confirmer</code>](#Confirmer)
+Low level utility to construct a new `Confirmer` with a fulfillment. It is
+designed to easily wrap the internal promise/resolution in a `Confirmer`
+object.
+
+* if a `Confirmer` is passed it will be returned
+* if a `Promise` is passed it will become the internal promise of a new Confirmer
+* if an `Object` is passed it will become the fulfilled value of the internal promise of a new Confirmer
+
+**Warning:** Any other type will cause the Confirmer to reject with an
+error.
+
+The internal fulfillment value (either directly of as the result of a
+promise resolution) must be an Object with these properties:
+
+* reason `String` - the reason for the fulfillment. One of "confirmed", "cancelled", or "rejected".
+* value `Any` - the value associated (optional)
+
+**Kind**: static method of [<code>Confirmer</code>](#Confirmer)  
+**Returns**: [<code>Confirmer</code>](#Confirmer) - a new Confirmer that has/will be resolved to the result  
+**Params**
+
+- result [<code>Confirmer</code>](#Confirmer) | <code>Promise</code> | <code>Object</code> - the result the new Confirmer should resolve to
+
+
+* * *
+
 
 ## Examples
 

--- a/docs/README.hbs
+++ b/docs/README.hbs
@@ -1,0 +1,25 @@
+# Confirmed
+
+A framework agnostic asynchronous confirmation module.
+
+A very simple *promise-like* API for easily showing a confirmation and
+resolving to the result of the user input. Its main goal is to replace or
+enhance the typical `window.confirm` and many adhoc event based solutions (see
+example below).
+
+Special thanks to [FunnelCloud Inc.](http://funnelcloud.io/) for graciously
+providing inspiration, R+D, and support.
+
+License: MIT
+
+{{>install}}
+
+{{>requirements}}
+
+{{>usage}}
+
+## API
+
+{{>main}}
+
+{{>code_examples}}

--- a/docs/code_examples.hbs
+++ b/docs/code_examples.hbs
@@ -1,0 +1,120 @@
+## Examples
+
+The following are example situations that I've run into and how this module can
+help reason about them.
+
+### Basic `window.confirm`
+
+In this example we will wrap the `window.confirm`. Although this is **not**
+asynchronous it does illustrate the API.
+
+```js
+new Confirmer(function (resolver) {
+  if (confirm('Whould you like to do this?')) {
+    resolver.confirm();
+  } else {
+    resolver.cancel();
+  }
+})
+  .onConfirmed(function () { console.log('Ok! let\'s crack on!'); })
+  .onCancelled(function () { console.log('Maybe next time then?'); })
+  .onDone(function () { console.log('Confirm completed') });
+```
+
+### jQuery dialog
+
+Here we show how to toggle a modal dialog with jQuery.
+
+```js
+new Confirmer(function (resolver) {
+  $('#modal-dialog button.yes').one('click', resolver.confirm);
+  $('#modal-dialog button.no').one('click', resolver.cancel);
+  $('#modal-dialog').show();
+})
+  .onConfirmed(function () { console.log('Ok! let\'s crack on!'); })
+  .onCancelled(function () { console.log('Maybe next time then?'); })
+  .onDone(function () {
+    $('#modal-dialog button').off('click');
+    $('#modal-dialog').hide();
+  });
+```
+
+### Password prompt
+
+Maybe the resolution of the confirmation needs more logic. For example asking
+for a password.
+
+```js
+new Confirmer(function (resolver) {
+  function checkPassword() {
+    var passwd = $('#password-dialog input.passord').val();
+    if (passwd === 'password') {
+      resolver.confirm(123);
+    } else {
+      resolver.reject('incorrect password');
+    }
+  }
+  $('#password-dialog button.ok').one('click', checkPassword);
+  $('#password-dialog button.cancel').one('click', resolver.cancel);
+  $('#password-dialog').show();
+})
+  .onConfirmed(function (userID) {
+    console.log('User ' + userID + ', you may proceed.');
+  })
+  .onRejected(function (message) {
+    console.log('Access denied: ' + message);
+  })
+  .onDone(function () {
+    $('#password-dialog input.passord').val('');
+    $('#modal-dialog button').off('click');
+    $('#password-dialog').hide();
+  });
+```
+
+## Auto closing message box
+
+Here is an example of a message box that auto closes after 5 seconds.
+
+Notice that you can call the resolver functions multiple times and only the
+first one wins.
+
+```js
+new Confirmer(function (resolver) {
+  setTimeout(resolver.cancel, 5000);
+  $('#modal-dialog button.ok').one('click', resolver.confirm);
+  $('#modal-dialog').show();
+}).onDone(function () {
+  $('#modal-dialog button').off('click');
+  $('#modal-dialog').hide();
+});
+```
+
+## Vanilla DOM Events (using the dispose function)
+
+Because vanilla DOM events are a common area for memory leaks the expectation
+is that when you `addEventListener` you have a corresponding
+`removeEventListener`. Unfortunately this requires a reference to the event
+handler function. This is typically accomplished using named functions.
+However, that also adds scope problems and more boilerplate. Some attempt to
+use `arguments.callee`, some use `var _this = this`, and some use outer scoped
+variables. This example takes advantage of the `dispose` API to make disposing
+resources in a cleaner (read prettier) way.
+
+```js
+let dialog = document.getElementById('modal-dialog');
+let buttonYes = dialog.querySelector('button.yes');
+let buttonNo = dialog.querySelector('button.no');
+
+new Confirmer(function (resolver) {
+  buttonYes.addEventListener('click', resolver.confirm);
+  buttonNo.addEventListener('click', resolver.cancel);
+  resolver.dispose(function () {
+    buttonYes.removeEventListener('click', resolver.confirm);
+    buttonNo.removeEventListener('click', resolver.cancel);
+  });
+  dialog.style.display = 'block';
+})
+  .onConfirmed(function () { console.log('Ok! let\'s crack on!'); })
+  .onCancelled(function () { console.log('Maybe next time then?'); })
+  .onDone(function () { dialog.style.display = 'none'; });
+```

--- a/docs/install.hbs
+++ b/docs/install.hbs
@@ -1,0 +1,18 @@
+## Install
+
+Node.js:
+
+    npm install confirmed
+
+OR
+
+    yarn add confirmed
+
+Browser:
+
+```html
+<script type="text/javascript" src="/path/to/module/dist/confirmer.js"></script>
+```
+
+The `dist/confirmer.js` is a UMD module compatible with Node.js, AMD
+(require.js), and as a browser global.

--- a/docs/requirements.hbs
+++ b/docs/requirements.hbs
@@ -1,0 +1,6 @@
+## Requirements
+
+This package uses promises. You environment will need to have a `Promise`
+implementation. Most modern browsers and later versions of Node have such. If
+you use this in an environment that does not you will need to include a
+polyfill.

--- a/docs/usage.hbs
+++ b/docs/usage.hbs
@@ -1,0 +1,43 @@
+## Usage
+
+Much like the `Promise` API the constructor for the `Confirmer` takes
+a function. That function is passed a resolver object which has four functions
+on it that you can use to *fulfill* the `Confirmer`.
+
+```js
+new Confirmer(function (resolver) {
+  // Affirm confirmation
+  resolver.confirm();
+  // Reject confirmation
+  resolver.reject();
+  // Cancel confirmation
+  resolver.cancel();
+  // Reject with an Error
+  resolver.error(new Error());
+  // Register a disposer function to clean up resources
+  // Same as onDone but in the initializer function closure
+  resolver.dispose(function () { … });
+})
+```
+
+Each state can take an optional value. The `Confirmer` is a wrapper around
+a `Promise` and can be treated as a promise. For example to capture any errors
+or exceptions you may trigger you would use the `catch()` function.
+
+```js
+new Confirmer(function (resolver) { … })
+  .catch(function (reason) { console.error(reason); });
+```
+
+The `then()` function will be passed the underlying data object:
+
+```js
+new Confirmer(function (resolver) { … })
+  .then(function (result) {
+    console.log(result.reason);
+    console.log(result.value);
+  });
+```
+
+The `reason` being one of `rejected`, `confirmed`, or `cancelled`. And the
+`value` is the value passed to one of the resolver functions.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "url": "https://tritarget.org/"
   },
   "scripts": {
+    "preversion": "yarn run docs && git add README.md",
+    "docs": "jsdoc2md > README.md",
     "clean": "rm -r dist",
     "build": "babel src -d dist",
     "test": "npm run build && mocha",
@@ -31,7 +33,21 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
+    "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^3.4.2",
     "sinon": "^2.4.1"
+  },
+  "jsdoc2md": {
+    "template": "docs/README.hbs",
+    "files": [
+      "src/confirmer.js"
+    ],
+    "partial": "docs/*.hbs",
+    "no-gfm": false,
+    "global-index-format": "none",
+    "param-list-format": "list",
+    "separators": true,
+    "heading-depth": 3,
+    "example-lang": "js"
   }
 }

--- a/src/confirmer.js
+++ b/src/confirmer.js
@@ -2,7 +2,39 @@ export const REJECTED = 'rejected';
 export const CONFIRMED = 'confirmed';
 export const CANCELLED = 'cancelled';
 
-export default class Confirmer {
+/**
+ * The main class is referred to as `Confirmer` though the packaging is called
+ * `confirmed` This is simply to prevent an NPM name collision but the proper
+ * term for this utility is `Confirmer` and is referenced as such in this
+ * documentation.
+ */
+class Confirmer {
+  /**
+   * Much like the `Promise` API the constructor for the `Confirmer` takes a
+   * function. That function is passed a resolver object which has three
+   * functions on it that you can use to *fulfill* the `Confirmer`, one
+   * function to register an error, and a disposer function to clean up
+   * resources is needed. Each fulfillment function can take an optional value.
+   *
+   * #### Example
+   * ```js
+   * new Confirmer(function (resolver) {
+   *   // Affirm confirmation
+   *   resolver.confirm();
+   *   // Reject confirmation
+   *   resolver.reject();
+   *   // Cancel confirmation
+   *   resolver.cancel();
+   *   // Reject with an Error
+   *   resolver.error(new Error());
+   *   // Register a disposer function to clean up resources
+   *   // Same as onDone but in the initializer function closure
+   *   resolver.dispose(function () { … });
+   * });
+   * ```
+   *
+   * @param {Function} initFn The initializer function
+   */
   constructor(initFn) {
     let disposer = () => {};
     this._promise = new Promise((resolve, reject) => {
@@ -19,6 +51,19 @@ export default class Confirmer {
     );
   }
 
+  /**
+   * Register callback that is called when `resolver.confirm()` is triggered.
+   * Used to denote that the user has confirmed in some way. ("OK" button,
+   * correct login credentials, etc.)
+   *
+   * If the callback returns a new Confirmer the result will be that new
+   * Confirmer allowing the callback to change the fulfillment reason as part
+   * of the chaining. If it is simply a scalar value the fulfillment reason
+   * with remain the same but the value will change.
+   *
+   * @param {Function} fn callback function called when Confirmer is confirmed
+   * @return {Confirmer} A new Confirmer instance for chaining
+   */
   onConfirmed(fn) {
     let promise = this._promise.then(result => {
       if (result.reason !== CONFIRMED) { return result; }
@@ -30,6 +75,19 @@ export default class Confirmer {
     return Confirmer.resolve(promise);
   }
 
+  /**
+   * Register callback that is called when `resolver.rejected()` is triggered.
+   * Used to denote that the user has performed an action that denied the
+   * confirmation. ("No" button, bad password, etc.)
+   *
+   * If the callback returns a new Confirmer the result will be that new
+   * Confirmer allowing the callback to change the fulfillment reason as part
+   * of the chaining. If it is simply a scalar value the fulfillment reason
+   * with remain the same but the value will change.
+   *
+   * @param {Function} fn callback function called when Confirmer is rejected
+   * @return {Confirmer} A new Confirmer instance for chaining
+   */
   onRejected(fn) {
     let promise = this._promise.then(result => {
       if (result.reason !== REJECTED) { return result; }
@@ -41,6 +99,19 @@ export default class Confirmer {
     return Confirmer.resolve(promise);
   }
 
+  /**
+   * Register callback that is called when `resolver.cancel()` is triggered.
+   * Used to denote that the confirmation was cancelled and perhaps should do
+   * nothing.
+   *
+   * If the callback returns a new Confirmer the result will be that new
+   * Confirmer allowing the callback to change the fulfillment reason as part
+   * of the chaining. If it is simply a scalar value the fulfillment reason
+   * with remain the same but the value will change.
+   *
+   * @param {Function} fn callback function called when Confirmer is cancelled
+   * @return {Confirmer} A new Confirmer instance for chaining
+   */
   onCancelled(fn) {
     let promise = this._promise.then(result => {
       if (result.reason !== CANCELLED) { return result; }
@@ -52,10 +123,24 @@ export default class Confirmer {
     return Confirmer.resolve(promise);
   }
 
+  /**
+   * Spelling error; use `onCancelled`.
+   * @deprecated
+   */
   onCanceled(fn) {
     return this.onCancelled(fn);
   }
 
+  /**
+   * Register a callback that is called when any of the resolver functions are
+   * triggered. This is used for clean up like closing the dialog and removing
+   * stale event handlers. This is also called if the `resolver.error()` is
+   * triggered or something throws an exception in the initialization function
+   * (which can be captured by the `catch()` function just like a promise).
+
+   * @param {Function} fn callback function called when Confirmer is resolved/errored
+   * @return {Confirmer} A new Confirmer instance for chaining
+   */
   onDone(fn) {
     let promise = this._promise.then(
       result => Promise.resolve(fn()).then(() => result),
@@ -64,14 +149,54 @@ export default class Confirmer {
     return Confirmer.resolve(promise);
   }
 
+  /**
+   * Cast to a `Promise`. Will proxy to the internal promise `then()` method.
+   * Since the result is a Promise it will not chain as Confirmer after this.
+   *
+   * The result of a fulfilled promise is an Object with `reason` and `value`
+   * properties. See {@link Confirmer.resolve} for more details of this
+   * internal object.
+   *
+   * @param {Function} onFulfilled callback when internal promise is fulfilled
+   * @param {Function} onRejected  callback when internal promise is rejected
+   * @return {Promise}
+   */
   then() {
     return this._promise.then(...arguments);
   }
 
+  /**
+   * Cast to a `Promise`. Will proxy to the internal promise `catch()` method.
+   * Since the result is a Promise it will not chain as Confirmer after this.
+   *
+   * @param {Function} onRejected  callback when internal promise is rejected
+   * @return {Promise}
+   */
   catch(fn) {
     return this._promise.then(null, fn);
   }
 
+  /**
+   * Low level utility to construct a new `Confirmer` with a fulfillment. It is
+   * designed to easily wrap the internal promise/resolution in a `Confirmer`
+   * object.
+   *
+   * * if a `Confirmer` is passed it will be returned
+   * * if a `Promise` is passed it will become the internal promise of a new Confirmer
+   * * if an `Object` is passed it will become the fulfilled value of the internal promise of a new Confirmer
+   *
+   * **Warning:** Any other type will cause the Confirmer to reject with an
+   * error.
+   *
+   * The internal fulfillment value (either directly of as the result of a
+   * promise resolution) must be an Object with these properties:
+   *
+   * * reason `String` - the reason for the fulfillment. One of "confirmed", "cancelled", or "rejected".
+   * * value `Any` - the value associated (optional)
+   *
+   * @param {Confirmer|Promise|Object} result the result the new Confirmer should resolve to
+   * @return {Confirmer} a new Confirmer that has/will be resolved to the result
+   */
   static resolve(result) {
     if (result instanceof Confirmer) { return result; }
     let newConfirmer = new Confirmer(() => {});
@@ -85,3 +210,5 @@ export default class Confirmer {
     return newConfirmer;
   }
 }
+
+export default Confirmer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,24 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+align-text@^0.1.1, align-text@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+  dependencies:
+    kind-of "^3.0.2"
+    longest "^1.0.1"
+    repeat-string "^1.5.2"
+
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-escape-sequences@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz#e0ecb042958b71e42942d35c1fcf1d9b00a0f67e"
+  dependencies:
+    array-back "^2.0.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -39,6 +57,13 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argv-tools@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/argv-tools/-/argv-tools-0.1.1.tgz#588283f3393ada47141440b12981cd41bf6b7032"
+  dependencies:
+    array-back "^2.0.0"
+    find-replace "^2.0.1"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -48,6 +73,18 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+array-back@^1.0.2, array-back@^1.0.3, array-back@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
+  dependencies:
+    typical "^2.6.0"
+
+array-back@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
+  dependencies:
+    typical "^2.6.1"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -68,6 +105,10 @@ assert-plus@^0.2.0:
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -504,6 +545,10 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@7.0.0-beta.19:
+  version "7.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
+
 babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
@@ -527,6 +572,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@~3.5.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 boom@2.x.x:
   version "2.10.1"
@@ -553,9 +602,34 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+cache-point@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cache-point/-/cache-point-0.4.1.tgz#cc8c9cbd99d90d7b0c66910cd33d77a1aab8840e"
+  dependencies:
+    array-back "^2.0.0"
+    fs-then-native "^2.0.0"
+    mkdirp2 "^1.0.3"
+
+camelcase@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+catharsis@~0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.9.tgz#98cc890ca652dd2ef0e70b37925310ff9e90fc8b"
+  dependencies:
+    underscore-contrib "~0.3.0"
+
+center-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
+  dependencies:
+    align-text "^0.1.3"
+    lazy-cache "^1.0.3"
 
 chalk@^1.1.0:
   version "1.1.3"
@@ -582,6 +656,14 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+cliui@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+  dependencies:
+    center-align "^0.1.1"
+    right-align "^0.1.1"
+    wordwrap "0.0.2"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -590,11 +672,47 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collect-all@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collect-all/-/collect-all-1.0.3.tgz#1abcc20448b58a1447487fcf34130e9512b0acf8"
+  dependencies:
+    stream-connect "^1.0.2"
+    stream-via "^1.0.4"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
+
+command-line-args@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.0.2.tgz#c4e56b016636af1323cf485aa25c3cb203dfbbe4"
+  dependencies:
+    argv-tools "^0.1.1"
+    array-back "^2.0.0"
+    find-replace "^2.0.1"
+    lodash.camelcase "^4.3.0"
+    typical "^2.6.1"
+
+command-line-tool@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/command-line-tool/-/command-line-tool-0.8.0.tgz#b00290ef1dfc11cc731dd1f43a92cfa5f21e715b"
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    command-line-args "^5.0.0"
+    command-line-usage "^4.1.0"
+    typical "^2.6.1"
+
+command-line-usage@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-4.1.0.tgz#a6b3b2e2703b4dcf8bd46ae19e118a9a52972882"
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    table-layout "^0.4.2"
+    typical "^2.6.1"
 
 commander@2.9.0:
   version "2.9.0"
@@ -606,9 +724,19 @@ commander@^2.8.1:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+common-sequence@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/common-sequence/-/common-sequence-1.0.2.tgz#30e07f3f8f6f7f9b3dee854f20b2d39eee086de8"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+config-master@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/config-master/-/config-master-3.1.0.tgz#667663590505a283bf26a484d68489d74c5485da"
+  dependencies:
+    walk-back "^2.0.1"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -650,9 +778,17 @@ debug@^2.1.1, debug@^2.2.0:
   dependencies:
     ms "2.0.0"
 
+decamelize@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deep-extend@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.0.tgz#6ef4a09b05f98b0e358d6d93d4ca3caec6672803"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -676,13 +812,30 @@ diff@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
+dmd@^3.0.10:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/dmd/-/dmd-3.0.12.tgz#2aad884cd582287f7dc748435017c7dbd510fe0c"
+  dependencies:
+    array-back "^2.0.0"
+    cache-point "^0.4.1"
+    common-sequence "^1.0.2"
+    file-set "^2.0.0"
+    handlebars "^4.0.11"
+    marked "^0.3.16"
+    object-get "^2.1.0"
+    reduce-flatten "^1.0.1"
+    reduce-unique "^1.0.0"
+    reduce-without "^1.0.1"
+    test-value "^3.0.0"
+    walk-back "^3.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -716,6 +869,13 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+file-set@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-set/-/file-set-2.0.0.tgz#11831a388ec378aba881311a94f69814118849c3"
+  dependencies:
+    array-back "^2.0.0"
+    glob "^7.1.2"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -729,6 +889,13 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+find-replace@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-2.0.1.tgz#6d9683a7ca20f8f9aabeabad07e4e2580f528550"
+  dependencies:
+    array-back "^2.0.0"
+    test-value "^3.0.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -761,6 +928,10 @@ formatio@1.2.0:
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+
+fs-then-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fs-then-native/-/fs-then-native-2.0.0.tgz#19a124d94d90c22c8e045f2e8dd6ebea36d48c67"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -833,7 +1004,7 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -848,7 +1019,7 @@ globals@^9.0.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -859,6 +1030,16 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4:
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
+handlebars@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -1026,9 +1207,69 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js2xmlparser@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
+  dependencies:
+    xmlcreate "^1.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdoc-api@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/jsdoc-api/-/jsdoc-api-4.0.3.tgz#f87357856349a0be40a03e64711c34c74754ba20"
+  dependencies:
+    array-back "^2.0.0"
+    cache-point "^0.4.1"
+    collect-all "^1.0.3"
+    file-set "^2.0.0"
+    fs-then-native "^2.0.0"
+    jsdoc "~3.5.5"
+    object-to-spawn-args "^1.1.1"
+    temp-path "^1.0.0"
+    walk-back "^3.0.0"
+
+jsdoc-parse@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz#1194d6a16a2dfbe5fb8cccfeb5058ea808759893"
+  dependencies:
+    array-back "^2.0.0"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    reduce-extract "^1.0.0"
+    sort-array "^2.0.0"
+    test-value "^3.0.0"
+
+jsdoc-to-markdown@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz#247f7d977ecc209428972ec92ca14bd4e610355d"
+  dependencies:
+    array-back "^2.0.0"
+    command-line-tool "^0.8.0"
+    config-master "^3.1.0"
+    dmd "^3.0.10"
+    jsdoc-api "^4.0.1"
+    jsdoc-parse "^3.0.1"
+    walk-back "^3.0.0"
+
+jsdoc@~3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
+  dependencies:
+    babylon "7.0.0-beta.19"
+    bluebird "~3.5.0"
+    catharsis "~0.8.9"
+    escape-string-regexp "~1.0.5"
+    js2xmlparser "~3.0.0"
+    klaw "~2.0.0"
+    marked "~0.3.6"
+    mkdirp "~0.5.1"
+    requizzle "~0.2.1"
+    strip-json-comments "~2.0.1"
+    taffydb "2.6.2"
+    underscore "~1.8.3"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -1085,6 +1326,16 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
+klaw@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.0.0.tgz#59c128e0dc5ce410201151194eeb9cbf858650f6"
+  dependencies:
+    graceful-fs "^4.1.9"
+
+lazy-cache@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -1107,6 +1358,10 @@ lodash._getnative@^3.0.0:
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
 lodash.create@3.1.1:
   version "3.1.1"
@@ -1132,6 +1387,18 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
+lodash.padend@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
 lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -1140,11 +1407,19 @@ lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
 loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+marked@^0.3.16, marked@~0.3.6:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -1188,7 +1463,15 @@ minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1:
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
+mkdirp2@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp2/-/mkdirp2-1.0.3.tgz#cc8dd8265f1f06e2d8f5b10b6e52f4e050bed21b"
+
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1274,6 +1557,14 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-get@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/object-get/-/object-get-2.1.0.tgz#722bbdb60039efa47cad3c6dc2ce51a85c02c5ae"
+
+object-to-spawn-args@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz#77da8827f073d011c9e1b173f895781470246785"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -1286,6 +1577,13 @@ once@^1.3.0, once@^1.3.3:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -1390,6 +1688,26 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+reduce-extract@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-extract/-/reduce-extract-1.0.0.tgz#67f2385beda65061b5f5f4312662e8b080ca1525"
+  dependencies:
+    test-value "^1.0.1"
+
+reduce-flatten@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
+
+reduce-unique@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-unique/-/reduce-unique-1.0.0.tgz#7e586bcf87a4e32b6d7abd8277fad6cdec9f4803"
+
+reduce-without@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-without/-/reduce-without-1.0.1.tgz#68ad0ead11855c9a37d4e8256c15bbf87972fc8c"
+  dependencies:
+    test-value "^2.0.0"
+
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -1476,6 +1794,18 @@ request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+requizzle@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
+  dependencies:
+    underscore "~1.6.0"
+
+right-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+  dependencies:
+    align-text "^0.1.1"
+
 rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
@@ -1529,15 +1859,33 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+sort-array@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-array/-/sort-array-2.0.0.tgz#38a9c6da27fd7d147b42e60554f281187b4df472"
+  dependencies:
+    array-back "^1.0.4"
+    object-get "^2.1.0"
+    typical "^2.6.0"
+
 source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:
     source-map "^0.5.6"
 
+source-map@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -1552,6 +1900,16 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stream-connect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-connect/-/stream-connect-1.0.2.tgz#18bc81f2edb35b8b5d9a8009200a985314428a97"
+  dependencies:
+    array-back "^1.0.2"
+
+stream-via@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stream-via/-/stream-via-1.0.4.tgz#8dccbb0ac909328eb8bc8e2a4bd3934afdaf606c"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -1591,6 +1949,20 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+table-layout@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.3.tgz#07509e1d72599f2c128a58ac67682ec4ba002af0"
+  dependencies:
+    array-back "^2.0.0"
+    deep-extend "~0.5.0"
+    lodash.padend "^4.6.1"
+    typical "^2.6.1"
+    wordwrapjs "^3.0.0"
+
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
+
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
@@ -1611,6 +1983,31 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+temp-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-path/-/temp-path-1.0.0.tgz#24b1543973ab442896d9ad367dd9cbdbfafe918b"
+
+test-value@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-1.1.0.tgz#a09136f72ec043d27c893707c2b159bfad7de93f"
+  dependencies:
+    array-back "^1.0.2"
+    typical "^2.4.2"
+
+test-value@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
+  dependencies:
+    array-back "^1.0.3"
+    typical "^2.6.0"
+
+test-value@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-3.0.0.tgz#9168c062fab11a86b8d444dd968bb4b73851ce92"
+  dependencies:
+    array-back "^2.0.0"
+    typical "^2.6.1"
 
 text-encoding@0.6.4:
   version "0.6.4"
@@ -1644,9 +2041,40 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
+typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
+
+uglify-js@^2.6:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
+uglify-to-browserify@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+underscore-contrib@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
+  dependencies:
+    underscore "1.6.0"
+
+underscore@1.6.0, underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 user-home@^1.1.1:
   version "1.1.1"
@@ -1672,12 +2100,52 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
+walk-back@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-2.0.1.tgz#554e2a9d874fac47a8cb006bf44c2f0c4998a0a4"
+
+walk-back@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-3.0.0.tgz#2358787a35da91032dad5e92f80b12370d8795c5"
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
 
+window-size@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+wordwrap@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+
+wordwrapjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-3.0.0.tgz#c94c372894cadc6feb1a66bff64e1d9af92c5d1e"
+  dependencies:
+    reduce-flatten "^1.0.1"
+    typical "^2.6.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+xmlcreate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
+
+yargs@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  dependencies:
+    camelcase "^1.0.2"
+    cliui "^2.1.0"
+    decamelize "^1.0.0"
+    window-size "0.1.0"


### PR DESCRIPTION
The former chaining supported changing the value but not the reason. It did so by mutating the original Confirmer state. This meant that you couldn't chain Confirmers. For example it was not easy for an `onConfirmed` function to return a new Confirmer and continue the result like you could with promises.

- [x] Fix test
- [x] Document new API in README
- [x] Consider yuidocs

Example
-------

```js
new Confirmer(resolver => resolver.confirm('confirmed-value')
  .onConfirmed(() => new Confirmer(resolver => resolver.reject('rejected-value')))
  .onConfirmed(value => console.log('confirmed', value))
  .onRejected(value => console.log('rejected', value));

// Version 1.x result
//   confirmed confirmed-value
// Expected 2.x result
//   rejected rejected-value
```