### PR TITLE
Remove unused Promise reference

### DIFF
--- a/src/confirmer.js
+++ b/src/confirmer.js
@@ -205,7 +205,7 @@ class Confirmer {
    */
   static resolve(result) {
     if (result instanceof Confirmer) { return result; }
-    let newConfirmer = new Confirmer(() => {});
+    let newConfirmer = Object.create(Confirmer.prototype);
     newConfirmer._promise = Confirmer.Promise.resolve(result).then(result => {
       let reason = result && result.reason;
       if (![CONFIRMED, CANCELLED, REJECTED].includes(reason)) {


### PR DESCRIPTION
Prior to this change, we made an unused promise when we executed `Confirmer.resolve`. Using `Object.create()` prevents the creation of an useless Promise.